### PR TITLE
Update Ticker

### DIFF
--- a/http.go
+++ b/http.go
@@ -97,7 +97,7 @@ func handlePay(w http.ResponseWriter, r *http.Request) {
 		amount = amountInCurrency.DivRound(price, 6)
 	} else {
 		amount = amountInCurrency
-		currency = "NANO"
+		currency = "XNO"
 	}
 	currency = strings.ToUpper(currency)
 	payment := &Payment{


### PR DESCRIPTION
CoinMarketCap has updated the ticker for nano from "NANO" to "XNO".

Without this change, you would need to explicitly set `currency=XNO` otherwise your operation would fail. This change makes it so even if `currency` is not supplied, your operation will still succeed.